### PR TITLE
Fixes broken links to index.js.html in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line272">line 272</a>
+        <a href="doc/doc/index.js.html">index.js</a>, <a href="doc/doc/index.js.html#line272">line 272</a>
     </li></ul></dd>
     
 
@@ -427,7 +427,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line149">line 149</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line149">line 149</a>
     </li></ul></dd>
     
 
@@ -606,7 +606,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line162">line 162</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line162">line 162</a>
     </li></ul></dd>
     
 
@@ -759,7 +759,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line283">line 283</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line283">line 283</a>
     </li></ul></dd>
     
 
@@ -912,7 +912,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line173">line 173</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line173">line 173</a>
     </li></ul></dd>
     
 
@@ -1065,7 +1065,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line123">line 123</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line123">line 123</a>
     </li></ul></dd>
     
 
@@ -1271,7 +1271,7 @@ blobUtil.imgSrcToBlob(img.src).then(function (blob) {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line229">line 229</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line229">line 229</a>
     </li></ul></dd>
     
 
@@ -1450,7 +1450,7 @@ to support
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line86">line 86</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line86">line 86</a>
     </li></ul></dd>
     
 
@@ -1602,7 +1602,7 @@ to support browsers that only have the prefixed
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line102">line 102</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line102">line 102</a>
     </li></ul></dd>
     
 
@@ -1757,7 +1757,7 @@ to a <code>Blob</code>. Returns a Promise.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line186">line 186</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line186">line 186</a>
     </li></ul></dd>
     
 
@@ -1994,7 +1994,7 @@ will only paint the first frame of an animated GIF.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line255">line 255</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line255">line 255</a>
     </li></ul></dd>
     
 
@@ -2231,7 +2231,7 @@ will only paint the first frame of an animated GIF.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line211">line 211</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line211">line 211</a>
     </li></ul></dd>
     
 
@@ -2387,7 +2387,7 @@ to support browsers that only have the prefixed
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line113">line 113</a>
+        <a href="doc/index.js.html">index.js</a>, <a href="doc/index.js.html#line113">line 113</a>
     </li></ul></dd>
     
 


### PR DESCRIPTION
Hello :wave:

I've seen that all links to `index.js.html` in the documentation are broken and fixed them manually. I tried to run `npm run jsdoc` locally, but it didn't seem to have anything to with creating the main `index.html`? Although the footer says it has been automatically created. So I am not really sure this was the right approach to be honest.

Hope this looks good. If I did anything wrong, please tell me and I'll update my PR :)