### PR TITLE
Fixes headline for `createObjectURL` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ var myBlob = blobUtil.createBlob(['hello world'], {type: 'text/plain'});
 ```
 
 <a name="createObjectURL"></a>
-###createObjectURL(blob)
+### createObjectURL(blob)
 Shim for
 [URL.createObjectURL()](https://developer.mozilla.org/en-US/docs/Web/API/URL.createObjectURL)
 to support browsers that only have the prefixed


### PR DESCRIPTION
Couple of weeks ago I fixed the headlines in the README (https://github.com/nolanlawson/blob-util/pull/33), but apparently forgot  `createObjectURL`.

This fixes it :)